### PR TITLE
Do not give an error when the raw value is None.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not give an error when the raw value is None.  Give an empty
+  unicode string as output in that case.
+  [maurits]
 
 
 1.2.2 (2013-01-01)

--- a/plone/app/textfield/tests.py
+++ b/plone/app/textfield/tests.py
@@ -44,6 +44,13 @@ class TestIntegration(ptc.PloneTestCase):
         value = IWithText['text'].fromUnicode(u"Some **text**")
         self.assertEquals(u'<p>Some **text**</p>', value.output)
     
+    def testTransformNone(self):
+        from plone.app.textfield.value import RichTextValue
+        value = RichTextValue()
+        # Mostly, these calls simply should not give an error.
+        self.assertEquals(None, value.raw)
+        self.assertEquals(u'', value.output)
+
     def testTransformStructured(self):
         from zope.interface import Interface
         from plone.app.textfield import RichText
@@ -97,6 +104,37 @@ class TestIntegration(ptc.PloneTestCase):
         output = context.restrictedTraverse('@@text-transform/text')()
         self.assertEquals(u"<span>Some html</span>", output.strip())
     
+    def testTransformNoneView(self):
+        from zope.interface import Interface, implements
+        from plone.app.textfield import RichText
+        from plone.app.textfield.value import RichTextValue
+        from Products.CMFCore.PortalContent import PortalContent
+
+        class IWithText(Interface):
+
+            text = RichText(title=u"Text",
+                            default_mime_type='text/structured',
+                            output_mime_type='text/html')
+
+        class Context(PortalContent):
+            implements(IWithText)
+
+            id = 'context'
+            text = None
+
+        context = Context()
+        # None as value should not lead to errors.
+        context.text = RichTextValue()
+
+        self.portal._setObject('context', context)
+        context = self.portal['context']
+
+        output = context.restrictedTraverse('@@text-transform/text')()
+        self.assertEquals(u'', output.strip())
+
+        output = context.restrictedTraverse('@@text-transform/text/text/plain')()
+        self.assertEquals(u'', output.strip())
+
     def testWidgetExtract(self):
         from zope.interface import Interface, implements
         from plone.app.textfield import RichText

--- a/plone/app/textfield/transform.py
+++ b/plone/app/textfield/transform.py
@@ -19,6 +19,9 @@ class PortalTransformsTransformer(object):
         self.context = context
 
     def __call__(self, value, mimeType):
+        # shortcut it we have no data
+        if value.raw is None:
+            return u''
 
         # shortcut if we already have the right value
         if mimeType is value.mimeType:

--- a/plone/app/textfield/value.py
+++ b/plone/app/textfield/value.py
@@ -49,6 +49,8 @@ class RichTextValue(object):
 
     @property
     def raw_encoded(self):
+        if self._raw_holder.value is None:
+            return ''
         return self._raw_holder.value.encode(self.encoding)
     
     # the current mime type


### PR DESCRIPTION
Give an empty unicode string as output in that case.  We could return None too, does not really matter for me.

I see this in a client project on Plone 3.  The error may be caused by some whacky stuff we do there, based on a beta release of dexterity 1.0, but this pull request does restore the situation from before commit b0300b7f93d67ee52b4aa341dde09dfff60c2121.

(Note for myself: master does not work on Plone 3, due to changed imports.)
