### PR TITLE
Fixes to improve type handling for plone.app.textfield in Lists

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,10 @@ Changelog
 1.2.4 (unreleased)
 ------------------
 
+* Force WYSIWYG, so when we start with 'text/plain' (or another MIME),
+  selecting 'text/html' will cause TinyMCE to spring into life.
+  [lentinj]
+
 * Tell Products.TinyMCE what the MIME type is, so it doesn't have to work it out.
   [lentinj]
 

--- a/plone/app/textfield/widget_input.pt
+++ b/plone/app/textfield/widget_input.pt
@@ -50,6 +50,7 @@
                         portal_url         nocall:context/portal_url;
                         portal             portal_url/getPortalObject;
                         text_format        view/value/mimeType | view/field/default_mime_type;
+                        force_wysiwyg      python:True;
                         inputname          view/name;
                         inputvalue         view/value/raw | nothing;
                         here_url           request/getURL;


### PR DESCRIPTION
In Dexterity, if you have a schema.List of RichText fields (or Object field containing RichText), choosing MIME types doesn't work particularly well.

Products.TinyMCE's `getContentType()` cannot find the MIME type for more complicated forms, but we can just tell it what it is (see https://github.com/plone/Products.TinyMCE/pull/83), so do that. Without the TinyMCE pull request going in, this will do nothing.

And, somewhat more debatably, turn on `force_wysiwyg`. This doesn't override a user's editor setting or anything scary, what it means is that the tinymce HTML will be embedded into the page, regardless of MIME type. So if I have a 'text/plain' field, selecting 'text/html' will cause TinyMCE to spring into life, instead of doing nothing until I save & re-edit. 
