### PR TITLE
Fix marshaler decode to always set raw value as unicode

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,20 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Fix marshaler decode to always decode raw value into unicode
+  [datakurre]
+
+- Remove utils.getSiteEncoding, which was deprecated and not used anywhere.
+  [thet]
+
+- For Plone 5, support getting markup control panel settings from the registry,
+  while still supporting normal portal_properties access for Plone < 5.
+  [thet]
+
+- Resolved an interesting circular import case, which wasnt effective because
+  of sort order of imports
+  [thet]
+
 - For Plone 5, support getting markup control panel settings from the registry,
   while still supporting normal portal_properties access for Plone < 5.
   [thet]

--- a/plone/app/textfield/marshaler.py
+++ b/plone/app/textfield/marshaler.py
@@ -32,8 +32,12 @@ if HAVE_MARSHALER:
                 charset='utf-8',
                 contentType=None,
                 primary=False):
+            try:
+                unicode_value = value.decode(charset)
+            except UnicodeEncodeError:
+                unicode_value = value  # was already unicode
             return RichTextValue(
-                raw=value,
+                raw=unicode_value,
                 mimeType=contentType or self.field.default_mime_type,
                 outputMimeType=self.field.output_mime_type,
                 encoding=charset


### PR DESCRIPTION
RichTextValue.raw is defined to be unicode (schema.Text), but currently demarshaler set the value as as encoded string (as received as such from RFC822-message), which breaks some RichTextValue methods non-ascii values.