### PR TITLE
Fix negative equality bug RawValueHolder and RichTextValue introduced in 1.2.5

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix negative equality bug RawValueHolder and RichTextValue introduced in 1.2.5.
+  [jone]
 
 
 1.2.5 (2015-03-26)

--- a/plone/app/textfield/field.rst
+++ b/plone/app/textfield/field.rst
@@ -127,6 +127,11 @@ and `encoding`:
     >>> value != value2
     False
 
+    >>> value == None
+    False
+    >>> value != None
+    True
+
 
 Converting a value from unicode
 -------------------------------

--- a/plone/app/textfield/value.py
+++ b/plone/app/textfield/value.py
@@ -25,7 +25,10 @@ class RawValueHolder(Persistent):
         return self.value == other.value
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return NotImplemented
+        return not equal
 
 
 class RichTextValue(object):
@@ -113,4 +116,7 @@ class RichTextValue(object):
         return vars(self) == vars(other)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return NotImplemented
+        return not equal


### PR DESCRIPTION
The problem is that the ``__ne__`` implementation was wrong when the compared objects were not of the same type.

When ``__eq__`` is called with another type (e.g. ``None``), the implementation returned ``NotImplemented``.

When ``__ne__`` was called with another type, this lead to not ``NotImplemented``, which is ``False`` althought the result should be true in this case.

The fix is to change ``__ne__`` to also return ``NotImplemented`` when the type is different, so that python can solve the problem.

Fixes plone/Products.CMFPlone/issues/532