### PR TITLE
Fix broken links in RichTextValue.output transformations

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,10 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issue, where the ``RichTextValue.output`` was transforming relative to an
+  ``ISite`` object. This broke relative links and for subsites also internal
+  absolute links. Fixes: https://github.com/plone/plone.app.textfield/issues/7
+  [thet]
 
 
 1.2.6 (2015-05-31)

--- a/plone/app/textfield/value.py
+++ b/plone/app/textfield/value.py
@@ -86,7 +86,16 @@ class RichTextValue(object):
         request = getRequest()
         context_path = request.physicalPathFromURL(request.getURL())
         context_view = getSite().restrictedTraverse(context_path)
-        return self.output_relative_to(context_view.context)
+        if getattr(context_view, 'context', False):
+            # TODO - context can be anything. in case of indexing, it's just
+            # not available.
+            # The problem has to be fixed completly differently - maybe really
+            # calling ``output_relative_to`` from templates.
+            return self.output_relative_to(context_view.context)
+        else:
+            # Fallback
+            site = getSite()
+            return self.output_relative_to(site)
 
     def output_relative_to(self, context):
         """Transforms the raw value to the output mimetype, within a specified context.


### PR DESCRIPTION
Fix issue, where the RichTextValue.output was transforming relative to an ISite object. This broke relative links and for subsites also internal absolute links. Fixes: https://github.com/plone/plone.app.textfield/issues/7

Obsoletes branch: https://github.com/plone/plone.app.textfield/compare/thet-fix-issue7

@davisagli - Referring to the discussion in https://github.com/plone/plone.app.textfield/issues/7
Using ``output_relative_to`` isn't an option, as all templates are using just output. I don't really like the code for obtaining the context, but it was the only one I could come up with.

RFC, NOT READY TO MERGE!

No tests yet, as I want to discuss this issue first. I even have to reconstruct the testcases to provide examples, what was broken when. Wait for it.
