### PR TITLE
Enable the RichText field to work together with a simple ITextAreaWidget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.2.8 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Enable the ``RichText`` field to work together with a simple ``ITextAreaWidget``.
+  [jensens]
+
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,11 @@
 Introduction
 ============
 
-This package provides a zope.schema style field type called RichText which
-can be used to store a value with a related MIME type. The value can be
-transformed to an output MIME type, for example to transform from structured
-text to HTML.
+This package provides a zope.schema style field type called RichText which can be used to store a value with a related MIME type.
+The value can be transformed to an output MIME type, for example to transform from structured text to HTML.
+
+Basic Usage
+===========
 
 To use the field, place it in a schema like so::
 
@@ -21,74 +22,119 @@ To use the field, place it in a schema like so::
                 default=u"Default value"
             )
 
-This specifies the default MIME type of text content as well as the default
-output type, and a tuple of allowed types. All these values are optional.
-The default MIME type is 'text/html', and the default output type is
-'text/x-html-safe'. By default, ``allowed_mime_types`` is None, which means
-that the side-wide default set of allowable input MIME types will be permitted.
+This specifies the default MIME type of text content as well as the default output type,
+and a tuple of allowed types.
+All these values are optional.
+The default MIME type is 'text/html', and the default output type is 'text/x-html-safe'.
+By default, ``allowed_mime_types`` is None,
+which means that the side-wide default set of allowable input MIME types will be permitted.
 
-Note that the default value here is set to a unicode string, which will be
-considered to be of the default MIME type. This value is converted to a
-``RichTextValue`` object (see below) on field initialisation, so the
-``default`` property will be an object of this type.
+Note that the default value here is set to a Unicode string,
+which will be considered to be of the default MIME type.
+This value is converted to a ``RichTextValue`` object (see below) on field initialisation,
+so the ``default`` property will be an object of this type.
 
-The field actually stores an immutable object of type
-`plone.app.textfield.value.RichTextValue`. This object has the following
-attributes:
+The field actually stores an immutable object of type `plone.app.textfield.value.RichTextValue`.
+This object has the following attributes:
 
 raw
-    The raw value as a unicode string.
+    The raw value as a Unicode string.
 
 mimeType
     The MIME type of the raw text.
 
 output
-    A unicode string that represents the value transformed to the default output MIME type.
-    May be None if the transformation could not be completed successfully,
+    A Unicode string that represents the value transformed to the default output MIME type.
+    Maybe None if the transformation could not be completed successfully,
     but will be cached after it has been successfully transformed once.
 
 outputMimeType
-    The MIME type of the output string. 
+    The MIME type of the output string.
     This is normally copied from the field's ``output_mime_type`` property.
 
-That the ``output``, ``mimeType`` and ``outputMimeType`` properties will be
-stored in the same _p_jar as the parent content object, whilst the ``raw``
-value is stored in a separate persistent object. This is to optimise for the
-common case where the ``output`` is frequently accessed when the object is
-viewed (and thus should avoid a separate persistent object load), whereas the
-``raw`` value is infrequently accessed (and so should not take up memory
-unless specifically requested).
 
-Transformation takes place using an ``ITransformer`` adapter. The default
-implementation uses Plone's ``portal_transforms`` tool to convert form one
-MIME type to another. Note that ``Products.PortalTransforms`` must be installed
-for this to work, otherwise no default ITransformer adapter is registered.
-You can use the ``[portaltransforms]`` extra to add
-``Products.PortralTransforms`` as a dependency.
+Storage
+=======
 
-To invoke alternative transformations from a page template, you can use the
-following convenience syntax::
+The ``output``, ``mimeType`` and ``outputMimeType`` properties will be stored in the same _p_jar as the parent content object,
+whilst the ``raw`` value is stored in a separate persistent object.
+This is to optimize for the common case where the ``output`` is frequently accessed when the object is viewed
+(and thus should avoid a separate persistent object load),
+    whereas the ``raw`` value is infrequently accessed
+(and so should not take up memory unless specifically requested).
+
+
+Transformation
+==============
+
+Transformation takes place using an ``ITransformer`` adapter.
+The default implementation uses Plone's ``portal_transforms`` tool to convert from one MIME type to another.
+Note that ``Products.PortalTransforms`` must be installed for this to work,
+otherwise, no default ITransformer adapter is registered.
+You can use the ``[portaltransforms]`` extra to add ``Products.PortralTransforms`` as a dependency.
+
+To invoke alternative transformations from a page template,
+you can use the following convenience syntax::
 
   <div tal:content="structure context/@@text-transform/fieldName/text/plain" />
 
-Here ``fieldName`` is the name of the field (which must be found on ``context``
-and contain a ``RichTextValue``). ``text/plain`` is the desired output MIME
-type.
+Here ``fieldName`` is the name of the field
+(which must be found on ``context`` and contain a ``RichTextValue``).
+``text/plain`` is the desired output MIME type.
 
-The package also contains a ``plone.supermodel`` export/import handler, which
-will be configured if plone.supermodel is installed. You can use the
-``[supermodel]`` extra to add a ``plone.supermodel`` dependency.
+
+Optional Features
+=================
+
+The package also contains a ``plone.supermodel`` export/import handler,
+which will be configured if plone.supermodel is installed.
+You can use the ``[supermodel]`` extra to add a ``plone.supermodel`` dependency.
 
 A ``z3c.form`` widget will be installed if `z3c.form`` is installed.
 The ``[widget]`` extra will pull this dependency in if nothing else does.
 
-A ``plone.rfc822`` field marshaler will be installed if ``plone.rfc822`` is
-installed. The ``[marshaler]`` extra will pull this dependency in if nothing
-else does.
+A ``plone.rfc822`` field marshaler will be installed if ``plone.rfc822`` is installed.
+The ``[marshaler]`` extra will pull this dependency in if nothing else does.
 
-A ``plone.schemaeditor`` field factory will be installed if
-``plone.schemaeditor`` is installed. The ``editor`` extra will pull this
+A ``plone.schemaeditor`` field factory will be installed if ``plone.schemaeditor`` is installed.
+The ``editor`` extra will pull this
 dependency if nothing else does.
 
-See field.txt for more details about the field's behaviour, and handler.txt
-for more details about the plone.supermodel handler.
+
+Usage with Simple TextArea
+==========================
+
+Alternatively, the RichText Field may be used without a WYSIWYG editor displaying a simple TextArea on input,
+and formatted output as HTML on display.
+In this example, it is expected to have the ``plone.intelligenttext`` transform available.
+Also expected is ``plone.autoform`` and ``plone.app.z3cform`` to be installed.
+
+::
+
+    from z3c.form.browser.textarea import TextAreaFieldWidget
+    from plone.autoform.directives import widget
+
+    class ITest(Interface):
+
+        bodyText = RichText(
+                title=u"Intelligent text",
+                default_mime_type='text/x-web-intelligent',
+                allowed_mime_types=('text/x-web-intelligent', ),
+                output_mime_type='text/x-html-safe',
+                default=u"Default value"
+            )
+        widget(
+            'bodyText',
+            TextAreaFieldWidget,
+        )
+
+Input is a simple text.
+At display, an HTML in rendered by the transform and shown.
+To show HTML unescaped the output has to be 'text/x-html-safe'.
+
+
+Further Reading
+===============
+
+See field.txt for more details about the field's behavior,
+and handler.txt for more details about the plone.supermodel handler.

--- a/plone/app/textfield/widget.zcml
+++ b/plone/app/textfield/widget.zcml
@@ -1,36 +1,63 @@
 <configure
+    i18n_domain="plone.app.textfield"
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:z3c="http://namespaces.zope.org/z3c"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.app.textfield">
-
-  <include package="z3c.form" file="meta.zcml" />
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+  <include
+      file="meta.zcml"
+      package="z3c.form"
+  />
   <include package="z3c.form" />
-
-  <adapter factory=".widget.RichTextFieldWidget" />
-  <adapter factory=".widget.RichTextConverter"
-           for=".interfaces.IRichText
-                .widget.IRichTextWidget"/>
-
+  <!--
+    register data converter for RichTextWidget
+  -->
+  <adapter
+      factory=".widget.RichTextConverter"
+      for=".interfaces.IRichText
+           .widget.IRichTextWidget"
+  />
+  <!--
+    also register a data converter for the basic z3c.form ITextAreaWidget,
+    so it can be used without tinymce, i.e. in order to convert from
+    text/x-web-intelligent to text/x-safe-html.
+   -->
+  <adapter
+      factory=".widget.RichTextAreaConverter"
+      for=".interfaces.IRichText
+           z3c.form.interfaces.ITextAreaWidget"
+  />
+  <!--
+      register new widget
+  -->
   <class class=".widget.RichTextWidget">
-      <require
-          permission="zope.Public"
-          interface=".widget.IRichTextWidget"
-      />
+    <require
+        interface=".widget.IRichTextWidget"
+        permission="zope.Public"
+    />
   </class>
-
   <z3c:widgetTemplate
+      layer="z3c.form.interfaces.IFormLayer"
       mode="display"
-      widget=".widget.IRichTextWidget"
-      layer="z3c.form.interfaces.IFormLayer"
       template="widget_display.pt"
-      />
-
-  <z3c:widgetTemplate
-      mode="input"
       widget=".widget.IRichTextWidget"
+  />
+  <z3c:widgetTemplate
       layer="z3c.form.interfaces.IFormLayer"
+      mode="input"
       template="widget_input.pt"
-      />
-
+      widget=".widget.IRichTextWidget"
+  />
+  <adapter factory=".widget.RichTextFieldWidget" />
+  <!--
+    register alternative template for ITextAreaWidget display in order to
+    render RichValue as structure
+  -->
+  <z3c:widgetTemplate
+      layer="plone.app.z3cform.interfaces.IPloneFormLayer"
+      mode="display"
+      template="widget_textarea_display.pt"
+      widget="z3c.form.interfaces.ITextAreaWidget"
+      zcml:condition="installed plone.app.z3cform"
+  />
 </configure>

--- a/plone/app/textfield/widget_textarea_display.pt
+++ b/plone/app/textfield/widget_textarea_display.pt
@@ -1,0 +1,28 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag=""
+      tal:define="safe_structure python:getattr(view.field, 'output_mime_type', None) == 'text/x-html-safe'">
+    <span id="" class=""
+          tal:attributes="id view/id;
+                          class view/klass;
+                          style view/style;
+                          title view/title;
+                          lang view/lang;
+                          onclick view/onclick;
+                          ondblclick view/ondblclick;
+                          onmousedown view/onmousedown;
+                          onmouseup view/onmouseup;
+                          onmouseover view/onmouseover;
+                          onmousemove view/onmousemove;
+                          onmouseout view/onmouseout;
+                          onkeypress view/onkeypress;
+                          onkeydown view/onkeydown;
+                          onkeyup view/onkeyup"><tal:block
+          condition="view/value"><tal:block
+            tal:condition="safe_structure"
+            content="structure view/value"
+          ></tal:block><tal:block
+            condition="not: safe_structure"
+            content="view/value"
+          ></tal:block></tal:block></span>
+</html>


### PR DESCRIPTION
added DataConverter for this case and provided a widget template on display for the ITextArea.