### PR TITLE
Made sure the new textarea template is not used for rich text widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Made sure the new simple textarea template is not used for rich text widgets,
+  but only for simple textarea widgets.  Otherwise you see this in the display:
+  ``RichTextValue object. (Did you mean .raw or .output?)``.
+  Fixes `issue 22 <https://github.com/plone/plone.app.textfield/issues/22>`_.
+  [maurits]
 
 
 1.2.8 (2017-02-05)

--- a/plone/app/textfield/tests.py
+++ b/plone/app/textfield/tests.py
@@ -166,7 +166,7 @@ class TestIntegration(PloneTestCase):
             u"<p>Sample <strong>text</strong></p>",
             value.output.strip())
 
-    def testWidgetConverter(self):
+    def testRichTextWidgetConverter(self):
         from zope.interface import Interface
         from plone.app.textfield import RichText
         from zope.publisher.browser import TestRequest
@@ -190,8 +190,79 @@ class TestIntegration(PloneTestCase):
         widget.update()
 
         converter = RichTextConverter(IWithText['text'], widget)
+
+        # Test with None input.
+        self.assertRaises(ValueError, converter.toFieldValue, None)
+        self.assertTrue(converter.toWidgetValue(None) is None)
+
+        # Test with string input.
+        self.assertRaises(ValueError, converter.toFieldValue, '')
+        self.assertRaises(ValueError, converter.toFieldValue, 'Foo')
+        self.assertRaises(ValueError, converter.toWidgetValue, '')
+        self.assertRaises(ValueError, converter.toWidgetValue, 'Foo')
+
+        # Test with unicode input.
         self.assertTrue(converter.toFieldValue(u'') is _marker)
+        self.assertEqual(converter.toFieldValue(u'Foo').raw, u'Foo')
+        self.assertTrue(isinstance(converter.toFieldValue(u'Foo'), RichTextValue))
+        self.assertEqual(converter.toWidgetValue(u'').raw, u'')
+        self.assertEqual(converter.toWidgetValue(u'Foo').raw, u'Foo')
+
+        # Test with RichTextValue input.
         self.assertTrue(converter.toFieldValue(RichTextValue(u'')) is _marker)
+        rich_text = RichTextValue(u'Foo')
+        self.assertEqual(converter.toFieldValue(rich_text), rich_text)
+        self.assertEqual(converter.toFieldValue(rich_text).raw, u'Foo')
+        self.assertEqual(converter.toWidgetValue(rich_text), rich_text)
+
+    def testRichTextAreaWidgetConverter(self):
+        from zope.interface import Interface
+        from plone.app.textfield import RichText
+        from zope.publisher.browser import TestRequest
+        from plone.app.textfield.value import RichTextValue
+        from plone.app.textfield.widget import RichTextWidget
+        from plone.app.textfield.widget import RichTextAreaConverter
+        from z3c.form.widget import FieldWidget
+
+        _marker = object()
+
+        class IWithText(Interface):
+
+            text = RichText(title=u"Text",
+                            default_mime_type='text/structured',
+                            output_mime_type='text/html',
+                            missing_value=_marker)
+
+        request = TestRequest()
+
+        widget = FieldWidget(IWithText['text'], RichTextWidget(request))
+        widget.update()
+
+        converter = RichTextAreaConverter(IWithText['text'], widget)
+
+        # Test with None input.
+        self.assertRaises(ValueError, converter.toFieldValue, None)
+        self.assertTrue(converter.toWidgetValue(None) is None)
+
+        # Test with string input.
+        self.assertTrue(converter.toFieldValue('') is _marker)
+        self.assertRaises(ValueError, converter.toFieldValue, 'Foo')
+        self.assertRaises(ValueError, converter.toWidgetValue, '')
+        self.assertRaises(ValueError, converter.toWidgetValue, 'Foo')
+
+        # Test with unicode input.
+        self.assertTrue(converter.toFieldValue(u'') is _marker)
+        self.assertEqual(converter.toFieldValue(u'Foo').raw, u'Foo')
+        self.assertTrue(isinstance(converter.toFieldValue(u'Foo'), RichTextValue))
+        self.assertEqual(converter.toWidgetValue(u''), u'')
+        self.assertEqual(converter.toWidgetValue(u'Foo'), u'Foo')
+
+        # Test with RichTextValue input.
+        self.assertTrue(converter.toFieldValue(RichTextValue(u'')) is _marker)
+        rich_text = RichTextValue(u'Foo')
+        self.assertEqual(converter.toFieldValue(rich_text), rich_text)
+        self.assertEqual(converter.toFieldValue(rich_text).raw, u'Foo')
+        self.assertEqual(converter.toWidgetValue(rich_text), u'Foo')
 
     def testWidgetAllowedTypesDefault(self):
         from zope.interface import Interface, implementer

--- a/plone/app/textfield/widget.py
+++ b/plone/app/textfield/widget.py
@@ -141,6 +141,10 @@ class RichTextAreaConverter(BaseDataConverter):
                 outputMimeType=self.field.output_mime_type,
                 encoding='utf-8'
             )
+        elif IRichTextValue.providedBy(value):
+            if value.raw == u'':
+                return self.field.missing_value
+            return value
         raise ValueError(
             'Can not convert {0:s} to an IRichTextValue'.format(repr(value))
         )

--- a/plone/app/textfield/widget.zcml
+++ b/plone/app/textfield/widget.zcml
@@ -52,12 +52,22 @@
   <!--
     register alternative template for ITextAreaWidget display in order to
     render RichValue as structure
+    But then we must reregister the template for our IRichTextWidget
+    for the IPloneFormLayer, otherwise widget_textarea_display.pt
+    will be used for both, which gives wrong results.
   -->
-  <z3c:widgetTemplate
+  <configure zcml:condition="installed plone.app.z3cform">
+    <z3c:widgetTemplate
       layer="plone.app.z3cform.interfaces.IPloneFormLayer"
       mode="display"
       template="widget_textarea_display.pt"
       widget="z3c.form.interfaces.ITextAreaWidget"
-      zcml:condition="installed plone.app.z3cform"
-  />
+    />
+    <z3c:widgetTemplate
+      layer="plone.app.z3cform.interfaces.IPloneFormLayer"
+      mode="display"
+      template="widget_display.pt"
+      widget=".widget.IRichTextWidget"
+    />
+  </configure>
 </configure>


### PR DESCRIPTION
Only use it for simple textarea widgets.  Otherwise you see this in the display:
`RichTextValue object. (Did you mean .raw or .output?)`.

Fixes issue #22.