### PR TITLE
Avoid a deprecation warning

### DIFF
--- a/news/42.misc
+++ b/news/42.misc
@@ -1,0 +1,1 @@
+Resolve deprecation warning [gfrorcada]

--- a/plone/app/textfield/utils.py
+++ b/plone/app/textfield/utils.py
@@ -7,7 +7,7 @@ try:
     from Products.CMFPlone.interfaces import IMarkupSchema
     from plone.registry.interfaces import IRegistry
     from zope.component import getUtility
-    from zope.component.interfaces import ComponentLookupError
+    from zope.interface.interfaces import ComponentLookupError
 except ImportError:
     IMarkupSchema = None
 


### PR DESCRIPTION
It should be safe to merge, the exception is defined in `zope.interface` since at least 9 years:
https://github.com/zopefoundation/zope.interface/commit/22f5e01a85f4331141ba782ac96879193f32f59b