### PR TITLE
Fixed deprecation warning for ComponentLookupError

### DIFF
--- a/news/43.bugfix
+++ b/news/43.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for ``zope.component.interfaces.ComponentLookupError``.
+[maurits]

--- a/plone/app/textfield/utils.py
+++ b/plone/app/textfield/utils.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.interface.interfaces import ComponentLookupError
 
 
 try:
     from Products.CMFPlone.interfaces import IMarkupSchema
-    from plone.registry.interfaces import IRegistry
-    from zope.component import getUtility
-    from zope.component.interfaces import ComponentLookupError
 except ImportError:
     IMarkupSchema = None
 


### PR DESCRIPTION
```
DeprecationWarning: ComponentLookupError is deprecated. Import from zope.interface.interfaces
```

And moved some imports out of the try/except ImportError which is only meant for IMarkupSchema.
With the original code, once the backwards compatibility import in zope.component is gone,
we would have gotten an ImportError for it, and the markup schema would not be available.