### PR TITLE
Fix access to wysiwyg editor settings

### DIFF
--- a/news/wysiwyg_editor_settings.bugfix
+++ b/news/wysiwyg_editor_settings.bugfix
@@ -1,0 +1,2 @@
+Fix usage of wysiwyg editor settings from portal_properties to registry
+[duchenean, gotcha]

--- a/plone/app/textfield/richtext_widget.rst
+++ b/plone/app/textfield/richtext_widget.rst
@@ -1,0 +1,62 @@
+==============
+RichTextWidget
+==============
+
+The widget can render a rich text field for a text:
+
+  >>> from zope.interface.verify import verifyClass
+  >>> from z3c.form import interfaces
+  >>> from plone.app.textfield.widget import RichTextWidget
+
+The ``RichTextWidget`` is a widget:
+
+  >>> verifyClass(interfaces.IWidget, RichTextWidget)
+  True
+
+The widget can render a input field only by adapting a request:
+
+  >>> from z3c.form.testing import TestRequest
+  >>> request = TestRequest()
+  >>> request.form['text'] = "<p>Hello world</p>"
+  >>> request.form['text.mimetype'] = "text/html"
+  >>> widget = RichTextWidget(request)
+  >>> widget.context = layer['portal']
+  >>> widget.name = 'text'
+  >>> from plone.app.textfield import RichText
+  >>> widget.field = RichText(allowed_mime_types=['text/html'])
+
+Such a widget provides IWidget:
+
+  >>> interfaces.IWidget.providedBy(widget)
+  True
+
+We also need to register the template for at least the widget and request:
+
+  >>> import os.path
+  >>> import zope.interface
+  >>> from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+  >>> from zope.pagetemplate.interfaces import IPageTemplate
+  >>> import plone.app.textfield
+  >>> import z3c.form.widget
+  >>> template = os.path.join(os.path.dirname(plone.app.textfield.__file__),
+  ...     'widget_input.pt')
+  >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+  >>> zope.component.provideAdapter(factory,
+  ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+  ...     IPageTemplate, name='input')
+
+If we render the widget we get the HTML:
+  >>> widget.update()
+  >>> print(widget.render())
+  <div xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" class="richTextWidget">
+    <input type="hidden" id="text_text_format" name="text.mimeType" value="text/html"/>
+    <div>
+      <textarea name="text" rows="25" class="pat-tinymce" id="text">&lt;p&gt;Hello world&lt;/p&gt;</textarea>
+    </div>
+  </div>
+  >>> from zope.component import getGlobalSiteManager
+  >>> gsm = getGlobalSiteManager()
+  >>> gsm.unregisterAdapter(factory,
+  ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+  ...     IPageTemplate, name='input')
+  True

--- a/plone/app/textfield/tests.py
+++ b/plone/app/textfield/tests.py
@@ -382,7 +382,23 @@ class Py23DocChecker(doctest.OutputChecker):
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 
+class TestTextfield(unittest.TestCase):
+    def test_getWysiwygEditor(self):
+        from plone.app.textfield.utils import getWysiwygEditor
+        editor = getWysiwygEditor(None, [], u"TinyMCE")
+        self.assertEquals(editor, u"tinymce")
+        editor = getWysiwygEditor(u"None", [], u"TinyMCE")
+        self.assertEquals(editor, u"plaintexteditor")
+        editor = getWysiwygEditor(u"TinyMCE", [u"TinyMCE", u"None"], u"TinyMCE")
+        self.assertEquals(editor, u"tinymce")
+        editor = getWysiwygEditor(u"CKeditor", [u"TinyMCE", u"None"], u"TinyMCE")
+        self.assertEquals(editor, u"tinymce")
+        editor = getWysiwygEditor(u"CKeditor", [u"TinyMCE", u"CKeditor", u"None"], u"TinyMCE")
+        self.assertEquals(editor, u"ckeditor")
+
+
 def test_suite():
+
     suite = unittest.makeSuite(TestIntegration)
     for doctestfile in ["field.rst", "handler.rst", "marshaler.rst"]:
         suite.addTest(
@@ -393,4 +409,11 @@ def test_suite():
                 layer=testing.PLONE_FIXTURE,
             )
         )
+    flags = \
+        doctest.NORMALIZE_WHITESPACE | \
+        doctest.ELLIPSIS | \
+        doctest.IGNORE_EXCEPTION_DETAIL
+    suite.addTest(layered(
+        doctest.DocFileSuite("richtext_widget.rst", optionflags=flags),
+        layer=testing.PLONE_INTEGRATION_TESTING))
     return suite

--- a/plone/app/textfield/utils.py
+++ b/plone/app/textfield/utils.py
@@ -7,6 +7,7 @@ from zope.interface.interfaces import ComponentLookupError
 
 
 try:
+    from Products.CMFPlone.interfaces import IEditingSchema
     from Products.CMFPlone.interfaces import IMarkupSchema
 except ImportError:
     IMarkupSchema = None
@@ -55,3 +56,38 @@ def getAllowedContentTypes():
         allowed_types = allowed - forbidden
 
     return allowed_types
+
+
+def getDefaultWysiwygEditor():
+    registry = getUtility(IRegistry)
+    try:
+        records = registry.forInterface(IEditingSchema, check=False,
+                                        prefix='plone')
+        default_editor = records.default_editor.lower()
+    except AttributeError:
+        default_editor = 'tinymce'
+    return default_editor
+
+
+def getAvailableWysiwygEditors():
+    registry = getUtility(IRegistry)
+    try:
+        records = registry.forInterface(IEditingSchema, check=False,
+                                        prefix='plone')
+        available = records.available_editors
+    except AttributeError:
+        available = ['TinyMCE']
+    return available
+
+
+def getWysiwygEditor(member_editor, available_editors, default_editor):
+    if member_editor is None:
+        return default_editor.lower()
+    elif member_editor == u'None':
+        return u'plaintexteditor'
+    elif member_editor in available_editors:
+        return member_editor.lower()
+    else:
+        # Member's wysiwyg_editor property holds
+        # wysiwyg_editor that has been uninstalled
+        return default_editor.lower()

--- a/plone/app/textfield/widget.py
+++ b/plone/app/textfield/widget.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 from Acquisition import ImplicitAcquisitionWrapper
+from Products.CMFCore.utils import getToolByName
 from plone.app.textfield.interfaces import IRichText
 from plone.app.textfield.interfaces import IRichTextValue
 from plone.app.textfield.utils import getAllowedContentTypes
+from plone.app.textfield.utils import getDefaultWysiwygEditor
+from plone.app.textfield.utils import getAvailableWysiwygEditors
+from plone.app.textfield.utils import getWysiwygEditor
 from plone.app.textfield.value import RichTextValue
 from plone.app.z3cform.utils import closest_content
 from z3c.form.browser.textarea import TextAreaWidget
@@ -76,6 +80,14 @@ class RichTextWidget(TextAreaWidget):
         if allowed is None:
             allowed = getAllowedContentTypes()
         return list(allowed)
+
+    def getWysiwygEditor(self):
+        tool = getToolByName(self.wrapped_context(), 'portal_membership')
+        member = tool.getAuthenticatedMember()
+        member_editor = member.getProperty('wysiwyg_editor')
+        available_editors = getAvailableWysiwygEditors()
+        default_editor = getDefaultWysiwygEditor()
+        return getWysiwygEditor(member_editor, available_editors, default_editor)
 
 
 @adapter(IRichText, IFormLayer)

--- a/plone/app/textfield/widget_input.pt
+++ b/plone/app/textfield/widget_input.pt
@@ -56,9 +56,7 @@
                         here_url           request/getURL;
                         member context/portal_membership/getAuthenticatedMember;
                         isAnon context/@@plone_portal_state/anonymous;
-                        member_editor python: not isAnon and member.getProperty('wysiwyg_editor').lower() or '';
-                        default_editor python: context.portal_properties.site_properties.getProperty('default_editor', '').lower();
-                        editor python: member_editor=='' and default_editor or member_editor;
+                        editor view/getWysiwygEditor;
                         support_path string:nocall:here/@@${editor}_wysiwyg_support|here/${editor}_wysiwyg_support|here/${editor}/wysiwyg_support|here/portal_skins/plone_wysiwyg/wysiwyg_support;
                         support python: path(support_path);
                         tabindex           nothing;


### PR DESCRIPTION
In Plone 5 wysiwyg editor settings have moved from portal_properties to registry.

This is the PR for master/Plone 6 (together with 5.2)

Antoine Duchêne contributor agreement is being prepared.