### PR TITLE
Config with default template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+#
+# EditorConfig Configuration file, for more details see:
+# http://EditorConfig.org
+# EditorConfig is a convention description, that could be interpreted
+# by multiple editors to enforce common coding conventions for specific
+# file types
+
+# top-most EditorConfig file:
+# Will ignore other EditorConfig files in Home directory or upper tree level.
+root = true
+
+
+[*]  # For All Files
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+# Set default charset
+charset = utf-8
+# Indent style default
+indent_style = space
+# Max Line Length - a hard line wrap, should be disabled
+max_line_length = off
+
+[*.{py,cfg,ini}]
+# 4 space indentation
+indent_size = 4
+
+[*.{yml,zpt,pt,dtml,zcml}]
+# 2 space indentation
+indent_size = 2
+
+[{Makefile,.gitmodules}]
+# Tab indentation (no size specified, but view as 4 spaces)
+indent_style = tab
+indent_size = unset
+tab_width = unset

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,0 +1,5 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+[meta]
+template = "default"
+commit-id = "80cf330f"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
+
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/collective/zpretty
+    rev: 3.0.2
+    hooks:
+    -   id: zpretty
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    -   id: codespell
+        additional_dependencies:
+          - tomli
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.49"
+    hooks:
+    -   id: check-manifest
+-   repo: https://github.com/regebro/pyroma
+    rev: "4.2"
+    hooks:
+    -   id: pyroma

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -188,7 +188,7 @@ Fixes:
   while still supporting normal portal_properties access for Plone < 5.
   [thet]
 
-- Resolved an interesting circular import case, which wasnt effective because
+- Resolved an interesting circular import case, which wasn't effective because
   of sort order of imports
   [thet]
 

--- a/news/80cf330f.internal
+++ b/news/80cf330f.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/plone/app/textfield/__init__.py
+++ b/plone/app/textfield/__init__.py
@@ -29,7 +29,7 @@ class RichText(Object):
         allowed_mime_types=None,
         max_length=None,
         schema=IRichTextValue,
-        **kw
+        **kw,
     ):
         self.default_mime_type = default_mime_type
         self.output_mime_type = output_mime_type

--- a/plone/app/textfield/browser.zcml
+++ b/plone/app/textfield/browser.zcml
@@ -1,14 +1,15 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="plone.app.textfield">
+    i18n_domain="plone.app.textfield"
+    >
 
   <!-- Generic transform browser view -->
   <browser:page
-      for="*"
       name="text-transform"
-      permission="zope2.View"
+      for="*"
       class=".browser.Transform"
+      permission="zope2.View"
       />
 
 </configure>

--- a/plone/app/textfield/configure.zcml
+++ b/plone/app/textfield/configure.zcml
@@ -1,31 +1,37 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.textfield">
+    i18n_domain="plone.app.textfield"
+    >
 
   <!-- Configure plone.supermodel support if available -->
-  <include zcml:condition="installed plone.supermodel"
+  <include
       file="handler.zcml"
+      zcml:condition="installed plone.supermodel"
       />
 
   <!-- Configure PortalTransforms based transformer if available -->
-  <include zcml:condition="installed Products.PortalTransforms"
+  <include
       file="transform.zcml"
+      zcml:condition="installed Products.PortalTransforms"
       />
 
   <!-- Configure z3c.form widget if z3c.form is installed -->
-  <include zcml:condition="installed z3c.form"
+  <include
       file="widget.zcml"
+      zcml:condition="installed z3c.form"
       />
 
   <!-- Configure plone.rfc822 marshaler if installed -->
-  <include zcml:condition="installed plone.rfc822"
+  <include
       file="marshaler.zcml"
+      zcml:condition="installed plone.rfc822"
       />
 
   <!-- Configure plone.schemaeditor field factory if installed -->
-  <include zcml:condition="installed plone.schemaeditor"
+  <include
       file="editor.zcml"
+      zcml:condition="installed plone.schemaeditor"
       />
 
   <!-- Configure transform invocation browser view -->

--- a/plone/app/textfield/editor.zcml
+++ b/plone/app/textfield/editor.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.app.textfield">
+    i18n_domain="plone.app.textfield"
+    >
 
   <class class=".RichText">
     <implements interface=".editor.IRichText" />

--- a/plone/app/textfield/field.rst
+++ b/plone/app/textfield/field.rst
@@ -101,12 +101,12 @@ Products.PortalTransforms, which in turn comes with Plone.
 Let's now access the output of our previously constructed value object again:
 
     >>> value.output
-    u'SOME PLAIN TEXT'
+    'SOME PLAIN TEXT'
 
 It is of course possible to get the raw value:
 
     >>> value.raw
-    u'Some plain text'
+    'Some plain text'
 
 Or to get the value encoded:
 
@@ -151,11 +151,11 @@ default MIME types set on the field.
     >>> value.outputMimeType
     'text/x-uppercase'
     >>> value.raw
-    u'A plain text string'
+    'A plain text string'
     >>> value.raw_encoded
     b'A plain text string'
     >>> value.output
-    u'A PLAIN TEXT STRING'
+    'A PLAIN TEXT STRING'
 
 Validation
 ----------
@@ -211,7 +211,7 @@ MIME types.
     RichTextValue object. (Did you mean <attribute>.raw or <attribute>.output?)
 
     >>> default_field.default.raw
-    u'Default value'
+    'Default value'
     >>> default_field.default.outputMimeType
     'text/x-uppercase'
     >>> default_field.default.mimeType

--- a/plone/app/textfield/handler.rst
+++ b/plone/app/textfield/handler.rst
@@ -47,7 +47,7 @@ Then, let's test the field
     ...     allowed_mime_types=('text/plain', 'text/html',))
     >>> fieldType = IFieldNameExtractor(field)()
     >>> handler = getUtility(IFieldExportImportHandler, name=fieldType)
-    >>> element = handler.write(field, u'dummy', fieldType) #doctest: +ELLIPSIS
+    >>> element = handler.write(field, 'dummy', fieldType) #doctest: +ELLIPSIS
     >>> print(prettyXML(element))
     <field name="dummy" type="plone.app.textfield.RichText">
       <allowed_mime_types>
@@ -90,15 +90,15 @@ To import:
     >>> reciprocal.__name__
     'dummy'
     >>> reciprocal.title
-    u'Test'
+    'Test'
     >>> reciprocal.description
-    u'Test desc'
+    'Test desc'
     >>> reciprocal.required
     False
     >>> reciprocal.readonly
     True
     >>> reciprocal.default.raw
-    u'Test default'
+    'Test default'
     >>> reciprocal.missing_value is None
     True
     >>> reciprocal.default_mime_type

--- a/plone/app/textfield/handler.zcml
+++ b/plone/app/textfield/handler.zcml
@@ -1,14 +1,13 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.app.textfield">
+    i18n_domain="plone.app.textfield"
+    >
 
   <!-- plone.supermodel configuration -->
   <utility
-      component=".handler.RichTextHandler"
       name="plone.app.textfield.RichText"
+      component=".handler.RichTextHandler"
       />
-  <adapter
-      factory=".handler.RichTextToUnicode"
-      />
+  <adapter factory=".handler.RichTextToUnicode" />
 
 </configure>

--- a/plone/app/textfield/marshaler.rst
+++ b/plone/app/textfield/marshaler.rst
@@ -40,7 +40,7 @@ we'll simply provide the output value directly::
     >>> from zope.interface import implementer
     >>> @implementer(ITestContent)
     ... class TestContent(object):
-    ...     _text = RichTextValue(u"Some \xd8 plain text", 'text/plain', 'text/html', 'utf-8', u'<p>Some \xd8 plain text</p>')
+    ...     _text = RichTextValue(u"Some \xd8 plain text", 'text/plain', 'text/html', 'utf-8', '<p>Some \xd8 plain text</p>')
 
     >>> t = TestContent()
 
@@ -57,7 +57,7 @@ The other way around::
 
     >>> decoded = marshaler.decode(b'Some nei\xc3\x9f plain text', charset='utf-8', contentType='text/plain')
     >>> decoded.raw
-    u'Some nei\xdf plain text'
+    'Some nei\xdf plain text'
     >>> decoded.mimeType
     'text/plain'
     >>> decoded.outputMimeType
@@ -76,7 +76,7 @@ the field's default type is used::
 
     >>> decoded = marshaler.decode(b'Some nei\xc3\x9f plain text')
     >>> decoded.raw
-    u'Some nei\xdf plain text'
+    'Some nei\xdf plain text'
     >>> decoded.mimeType
     'text/plain'
     >>> decoded.outputMimeType
@@ -110,7 +110,7 @@ Let's now use this message to construct a new object::
     >>> from plone.rfc822 import initializeObjectFromSchema
     >>> initializeObjectFromSchema(newContent, ITestContent, inputMessage)
     >>> newContent._text.raw
-    u'Some \xd8 plain text'
+    'Some \xd8 plain text'
     >>> newContent._text.mimeType
     'text/plain'
     >>> newContent._text.outputMimeType

--- a/plone/app/textfield/marshaler.zcml
+++ b/plone/app/textfield/marshaler.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.app.textfield">
+    i18n_domain="plone.app.textfield"
+    >
 
   <adapter factory=".marshaler.RichTextFieldMarshaler" />
 

--- a/plone/app/textfield/richtext_widget.rst
+++ b/plone/app/textfield/richtext_widget.rst
@@ -48,12 +48,13 @@ We also need to register the template for at least the widget and request:
 If we render the widget we get the HTML:
   >>> widget.update()
   >>> print(widget.render())
-  <div xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" class="richTextWidget">
-    <input type="hidden" id="text_text_format" name="text.mimeType" value="text/html"/>
-    <div>
-      <textarea name="text" rows="25" class="pat-tinymce" id="text">&lt;p&gt;Hello world&lt;/p&gt;</textarea>
-    </div>
-  </div>
+  <div xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" class="richTextWidget" >
+  ...<input type="hidden" id="text_text_format" name="text.mimeType" value="text/html" />
+  ...<div>
+  ...<textarea name="text" rows="25" class="pat-tinymce" id="text">&lt;p&gt;Hello world&lt;/p&gt;</textarea>
+  ...</div>
+  ...</div>
+
   >>> from zope.component import getGlobalSiteManager
   >>> gsm = getGlobalSiteManager()
   >>> gsm.unregisterAdapter(factory,

--- a/plone/app/textfield/tests.py
+++ b/plone/app/textfield/tests.py
@@ -3,7 +3,6 @@ from plone.testing import layered
 
 import doctest
 import plone.app.textfield
-import re
 import unittest
 
 
@@ -346,14 +345,6 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(3, value.getSize())
 
 
-class Py23DocChecker(doctest.OutputChecker):
-    def check_output(self, want, got, optionflags):
-        want = re.sub("u'(.*?)'", "'\\1'", want)
-        want = re.sub('u"(.*?)"', '"\\1"', want)
-
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
-
-
 class TestTextfield(unittest.TestCase):
     def test_getWysiwygEditor(self):
         from plone.app.textfield.utils import getWysiwygEditor
@@ -380,7 +371,6 @@ def test_suite():
                 doctest.DocFileSuite(
                     doctestfile,
                     optionflags=doctest.ELLIPSIS,
-                    checker=Py23DocChecker(),
                 ),
                 layer=testing.PLONE_FIXTURE,
             )

--- a/plone/app/textfield/transform.zcml
+++ b/plone/app/textfield/transform.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.app.textfield">
+    i18n_domain="plone.app.textfield"
+    >
 
   <adapter
       factory=".transform.PortalTransformsTransformer"

--- a/plone/app/textfield/widget.zcml
+++ b/plone/app/textfield/widget.zcml
@@ -1,13 +1,14 @@
 <configure
-    i18n_domain="plone.app.textfield"
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:z3c="http://namespaces.zope.org/z3c"
-    xmlns:zcml="http://namespaces.zope.org/zcml">
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="plone.app.textfield"
+    >
   <include
-      file="meta.zcml"
       package="z3c.form"
-  />
+      file="meta.zcml"
+      />
   <include package="z3c.form" />
   <!--
     register data converter for RichTextWidget
@@ -16,7 +17,7 @@
       factory=".widget.RichTextConverter"
       for=".interfaces.IRichText
            .widget.IRichTextWidget"
-  />
+      />
   <!--
     also register a data converter for the basic z3c.form ITextAreaWidget,
     so it can be used without tinymce, i.e. in order to convert from
@@ -26,28 +27,28 @@
       factory=".widget.RichTextAreaConverter"
       for=".interfaces.IRichText
            z3c.form.interfaces.ITextAreaWidget"
-  />
+      />
   <!--
       register new widget
   -->
   <class class=".widget.RichTextWidget">
     <require
-        interface=".widget.IRichTextWidget"
         permission="zope.Public"
-    />
+        interface=".widget.IRichTextWidget"
+        />
   </class>
   <z3c:widgetTemplate
+      widget=".widget.IRichTextWidget"
+      template="widget_display.pt"
       layer="z3c.form.interfaces.IFormLayer"
       mode="display"
-      template="widget_display.pt"
-      widget=".widget.IRichTextWidget"
-  />
+      />
   <z3c:widgetTemplate
+      widget=".widget.IRichTextWidget"
+      template="widget_input.pt"
       layer="z3c.form.interfaces.IFormLayer"
       mode="input"
-      template="widget_input.pt"
-      widget=".widget.IRichTextWidget"
-  />
+      />
   <adapter factory=".widget.RichTextFieldWidget" />
   <!--
     register alternative template for ITextAreaWidget display in order to
@@ -58,16 +59,16 @@
   -->
   <configure zcml:condition="installed plone.app.z3cform">
     <z3c:widgetTemplate
-      layer="plone.app.z3cform.interfaces.IPloneFormLayer"
-      mode="display"
-      template="widget_textarea_display.pt"
-      widget="z3c.form.interfaces.ITextAreaWidget"
-    />
+        widget="z3c.form.interfaces.ITextAreaWidget"
+        template="widget_textarea_display.pt"
+        layer="plone.app.z3cform.interfaces.IPloneFormLayer"
+        mode="display"
+        />
     <z3c:widgetTemplate
-      layer="plone.app.z3cform.interfaces.IPloneFormLayer"
-      mode="display"
-      template="widget_display.pt"
-      widget=".widget.IRichTextWidget"
-    />
+        widget=".widget.IRichTextWidget"
+        template="widget_display.pt"
+        layer="plone.app.z3cform.interfaces.IPloneFormLayer"
+        mode="display"
+        />
   </configure>
 </configure>

--- a/plone/app/textfield/widget_display.pt
+++ b/plone/app/textfield/widget_display.pt
@@ -1,18 +1,25 @@
-<div id="" class=""
-      tal:attributes="id view/id;
-                      class view/klass;
-                      style view/style;
-                      title view/title;
-                      lang view/lang;
-                      onclick view/onclick;
-                      ondblclick view/ondblclick;
-                      onmousedown view/onmousedown;
-                      onmouseup view/onmouseup;
-                      onmouseover view/onmouseover;
-                      onmousemove view/onmousemove;
-                      onmouseout view/onmouseout;
-                      onkeypress view/onkeypress;
-                      onkeydown view/onkeydown;
-                      onkeyup view/onkeyup"><tal:block
-      define="value view/value" condition="nocall:value" content="structure python:value.output_relative_to(view.context)"
-/></div>
+<div class=""
+     id=""
+     tal:attributes="
+       id view/id;
+       class view/klass;
+       style view/style;
+       title view/title;
+       lang view/lang;
+       onclick view/onclick;
+       ondblclick view/ondblclick;
+       onmousedown view/onmousedown;
+       onmouseup view/onmouseup;
+       onmouseover view/onmouseover;
+       onmousemove view/onmousemove;
+       onmouseout view/onmouseout;
+       onkeypress view/onkeypress;
+       onkeydown view/onkeydown;
+       onkeyup view/onkeyup;
+     "
+><tal:block define="
+               value view/value;
+             "
+             condition="nocall:value"
+             content="structure python:value.output_relative_to(view.context)"
+  /></div>

--- a/plone/app/textfield/widget_input.pt
+++ b/plone/app/textfield/widget_input.pt
@@ -1,72 +1,90 @@
-<div lang="en"
-     xml:lang="en"
-     xmlns="http://www.w3.org/1999/xhtml"
-     xmlns:tal="http://xml.zope.org/namespaces/tal"
-     xmlns:metal="http://xml.zope.org/namespaces/metal"
+<div xmlns="http://www.w3.org/1999/xhtml"
      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+     xmlns:metal="http://xml.zope.org/namespaces/metal"
+     xmlns:tal="http://xml.zope.org/namespaces/tal"
+     lang="en"
+     xml:lang="en"
+     tal:attributes="
+       class view/klass;
+       style view/style;
+       title view/title;
+       lang view/lang;
+       onclick view/onclick;
+       ondblclick view/ondblclick;
+       onmousedown view/onmousedown;
+       onmouseup view/onmouseup;
+       onmouseover view/onmouseover;
+       onmousemove view/onmousemove;
+       onmouseout view/onmouseout;
+       onkeypress view/onkeypress;
+       onkeydown view/onkeydown;
+       onkeyup view/onkeyup;
+     "
      i18n:domain="plone"
-     tal:attributes="class view/klass;
-                     style view/style;
-                     title view/title;
-                     lang view/lang;
-                     onclick view/onclick;
-                     ondblclick view/ondblclick;
-                     onmousedown view/onmousedown;
-                     onmouseup view/onmouseup;
-                     onmouseover view/onmouseover;
-                     onmousemove view/onmousemove;
-                     onmouseout view/onmouseout;
-                     onkeypress view/onkeypress;
-                     onkeydown view/onkeydown;
-                     onkeyup view/onkeyup">
+>
 
-    <tal:define define="fieldName view/name;
-                        mimeType view/value/mimeType | view/field/default_mime_type;
-                        allowedMimeTypes view/allowedMimeTypes">
+  <tal:define define="
+                fieldName view/name;
+                mimeType view/value/mimeType | view/field/default_mime_type;
+                allowedMimeTypes view/allowedMimeTypes;
+              ">
 
-        <div class="fieldTextFormat" tal:condition="python: len(allowedMimeTypes) > 1">
-            <label i18n:translate="label_text_format">Text Format</label>
+    <div class="fieldTextFormat"
+         tal:condition="python: len(allowedMimeTypes) &gt; 1"
+    >
+      <label i18n:translate="label_text_format">Text Format</label>
 
-            <select tal:attributes="id   string:${fieldName}_text_format;
-                                    name string:${fieldName}.mimeType;">
-                <option selected=""
-                    tal:repeat="item allowedMimeTypes"
-                    tal:attributes="selected python:item == mimeType and 'selected' or None;
-                                    value item;"
-                    tal:content="item" />
-            </select>
-        </div>
+      <select tal:attributes="
+                id   string:${fieldName}_text_format;
+                name string:${fieldName}.mimeType;
+              ">
+        <option selected
+                tal:repeat="item allowedMimeTypes"
+                tal:content="item"
+                tal:attributes="
+                  selected python:item == mimeType and 'selected' or None;
+                  value item;
+                "
+        ></option>
+      </select>
+    </div>
 
-        <tal:hidden condition="python: len(allowedMimeTypes) == 1">
-            <input type="hidden" tal:attributes="id string:${fieldName}_text_format;
-                                                 name string:${fieldName}.mimeType;
-                                                 value python:allowedMimeTypes[0]"/>
-        </tal:hidden>
-    </tal:define>
+    <tal:hidden condition="python: len(allowedMimeTypes) == 1">
+      <input type="hidden"
+             tal:attributes="
+               id string:${fieldName}_text_format;
+               name string:${fieldName}.mimeType;
+               value python:allowedMimeTypes[0];
+             "
+      />
+    </tal:hidden>
+  </tal:define>
 
-    <tal:editor define="context            view/wrapped_context;
-                        object             python:(not view.ignoreContext) and context or None;
-                        here               nocall:context;
-                        portal_url         nocall:context/portal_url;
-                        portal             portal_url/getPortalObject;
-                        text_format        view/value/mimeType | view/field/default_mime_type;
-                        force_wysiwyg      python:True;
-                        inputname          view/name;
-                        inputvalue         view/value/raw | nothing;
-                        here_url           request/getURL;
-                        member context/portal_membership/getAuthenticatedMember;
-                        isAnon context/@@plone_portal_state/anonymous;
-                        editor view/getWysiwygEditor;
-                        support_path string:nocall:here/@@${editor}_wysiwyg_support|here/${editor}_wysiwyg_support|here/${editor}/wysiwyg_support|here/portal_skins/plone_wysiwyg/wysiwyg_support;
-                        support python: path(support_path);
-                        tabindex           nothing;
-                        rows               python:view.rows or 25;
-                        cols               python:view.cols or 80;
-                        maxlength          python:view.field.max_length or None;
-                        field              view/field;">
-        <div metal:use-macro="support/macros/wysiwygEditorBox">
+  <tal:editor define="
+                context            view/wrapped_context;
+                object             python:(not view.ignoreContext) and context or None;
+                here               nocall:context;
+                portal_url         nocall:context/portal_url;
+                portal             portal_url/getPortalObject;
+                text_format        view/value/mimeType | view/field/default_mime_type;
+                force_wysiwyg      python:True;
+                inputname          view/name;
+                inputvalue         view/value/raw | nothing;
+                here_url           request/getURL;
+                member context/portal_membership/getAuthenticatedMember;
+                isAnon context/@@plone_portal_state/anonymous;
+                editor view/getWysiwygEditor;
+                support_path string:nocall:here/@@${editor}_wysiwyg_support|here/${editor}_wysiwyg_support|here/${editor}/wysiwyg_support|here/portal_skins/plone_wysiwyg/wysiwyg_support;
+                support python: path(support_path);
+                tabindex           nothing;
+                rows               python:view.rows or 25;
+                cols               python:view.cols or 80;
+                maxlength          python:view.field.max_length or None;
+                field              view/field;
+              ">
+    <div metal:use-macro="support/macros/wysiwygEditorBox">
             The WYSIWYG code
-        </div>
-    </tal:editor>
+    </div>
+  </tal:editor>
 
 </div>

--- a/plone/app/textfield/widget_textarea_display.pt
+++ b/plone/app/textfield/widget_textarea_display.pt
@@ -1,28 +1,32 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:define="
+        safe_structure python:getattr(view.field, 'output_mime_type', None) == 'text/x-html-safe';
+      "
       tal:omit-tag=""
-      tal:define="safe_structure python:getattr(view.field, 'output_mime_type', None) == 'text/x-html-safe'">
-    <span id="" class=""
-          tal:attributes="id view/id;
-                          class view/klass;
-                          style view/style;
-                          title view/title;
-                          lang view/lang;
-                          onclick view/onclick;
-                          ondblclick view/ondblclick;
-                          onmousedown view/onmousedown;
-                          onmouseup view/onmouseup;
-                          onmouseover view/onmouseover;
-                          onmousemove view/onmousemove;
-                          onmouseout view/onmouseout;
-                          onkeypress view/onkeypress;
-                          onkeydown view/onkeydown;
-                          onkeyup view/onkeyup"><tal:block
-          condition="view/value"><tal:block
-            tal:condition="safe_structure"
-            content="structure view/value"
-          ></tal:block><tal:block
-            condition="not: safe_structure"
-            content="view/value"
-          ></tal:block></tal:block></span>
+>
+  <span class=""
+        id=""
+        tal:attributes="
+          id view/id;
+          class view/klass;
+          style view/style;
+          title view/title;
+          lang view/lang;
+          onclick view/onclick;
+          ondblclick view/ondblclick;
+          onmousedown view/onmousedown;
+          onmouseup view/onmouseup;
+          onmouseover view/onmouseover;
+          onmousemove view/onmousemove;
+          onmouseout view/onmouseout;
+          onkeypress view/onkeypress;
+          onkeydown view/onkeydown;
+          onkeyup view/onkeyup;
+        "
+  ><tal:block condition="view/value"><tal:block tal:condition="safe_structure"
+                 content="structure view/value"
+      /><tal:block condition="not: safe_structure"
+                 content="view/value"
+      /></tal:block></span>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
 [tool.towncrier]
 filename = "CHANGES.rst"
 directory = "news/"
@@ -18,3 +20,43 @@ showcontent = true
 directory = "bugfix"
 name = "Bug fixes:"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "tests"
+name = "Tests"
+showcontent = true
+
+[tool.isort]
+profile = "plone"
+
+[tool.black]
+target-version = ["py38"]
+
+[tool.dependencychecker]
+Zope = [
+  # Zope own provided namespaces
+  'App', 'OFS', 'Products.Five', 'Products.OFSP', 'Products.PageTemplates',
+  'Products.SiteAccess', 'Shared', 'Testing', 'ZPublisher', 'ZTUtils',
+  'Zope2', 'webdav', 'zmi',
+  # Zope dependencies
+  'Acquisition', 'DateTime', 'transaction', 'zExceptions', 'ZODB', 'zope.component',
+  'zope.configuration', 'zope.container', 'zope.deferredimport', 'zope.event',
+  'zope.exceptions', 'zope.globalrequest', 'zope.i18n', 'zope.i18nmessageid',
+  'zope.interface', 'zope.lifecycleevent', 'zope.location', 'zope.publisher',
+  'zope.schema', 'zope.security', 'zope.site', 'zope.traversing', 'AccessControl',
+]
+'plone.base' = [
+  'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
+  'Products.CMFDynamicViewFTI', 'zope.deprecation',
+]
+python-dateutil = ['dateutil']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,23 @@
-[check-manifest]
-ignore =
-    *.cfg
-    bootstrap.py
-
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
 [bdist_wheel]
 universal = 0
 
-[isort]
-# black compatible Plone isort rules:
-profile = black
-force_alphabetical_sort = True
-force_single_line = True
-lines_after_imports = 2
+[flake8]
+doctests = 1
+ignore =
+    # black takes care of line length
+    E501,
+    # black takes care of where to break lines
+    W503,
+    # black takes care of spaces within slicing (list[:])
+    E203,
+    # black takes care of spaces after commas
+    E231,
 
+[check-manifest]
+ignore =
+    .editorconfig
+    .meta.toml
+    .pre-commit-config.yaml
+    tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,4 @@ deps =
 commands =
     zope-testrunner --test-path={toxinidir} -s plone.app.textfield
 extras =
-    test
+    tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,50 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+[tox]
+envlist =
+    format
+    lint
+    test
+
+[testenv]
+allowlist_externals =
+    sh
+
+[testenv:format]
+description = automatically reformat code
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit run -a pyupgrade
+    pre-commit run -a isort
+    pre-commit run -a black
+    pre-commit run -a zpretty
+
+[testenv:lint]
+description = run linters that will help improve the code style
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit run -a
+
+[testenv:dependencies]
+description = check if the package defines all its dependencies and generate a graph out of them
+deps =
+    z3c.dependencychecker==2.11
+    pipdeptree==2.5.1
+    graphviz  # optional dependency of pipdeptree
+commands =
+    dependencychecker
+    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
+
+[testenv:test]
+usedevelop = true
+deps =
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    zope-testrunner --test-path={toxinidir} -s plone.app.textfield
+extras =
+    test


### PR DESCRIPTION
Add the automation bits that were missing from @jensens PR earlier this/last week.

Regarding the dependencies `tox -e dependencies`, it reports:

```
Missing requirements
====================
     Products.PortalTransforms.cache.Cache
     persistent.Persistent
     plone.app.vocabularies
     plone.app.z3cform.utils.closest_content
     plone.registry.interfaces.IRegistry
     plone.rfc822.defaultfields.BaseFieldMarshaler
     plone.schemaeditor.fields.FieldFactory
     plone.supermodel.exportimport.BaseHandler
     plone.supermodel.interfaces.IToUnicode
     z3c.form
     z3c.form.browser.textarea.TextAreaWidget
     z3c.form.browser.widget.addFieldClass
     z3c.form.converter.BaseDataConverter
     z3c.form.interfaces.IFieldWidget
     z3c.form.interfaces.IFormLayer
     z3c.form.interfaces.ITextAreaWidget
     z3c.form.interfaces.NOVALUE
     z3c.form.widget.FieldWidget

Missing test requirements
=========================
     lxml.etree
     persistent.Persistent
     persistent.interfaces.IPersistent
     plone.rfc822.constructMessageFromSchema
     plone.rfc822.initializeObjectFromSchema
     plone.rfc822.interfaces.IFieldMarshaler
     plone.rfc822.interfaces.IPrimaryField
     plone.testing.layered
     z3c.form.interfaces
     z3c.form.interfaces.NOVALUE
     z3c.form.testing.TestRequest
     z3c.form.widget
     z3c.form.widget.FieldWidget
     zope.pagetemplate.interfaces.IPageTemplate
```

Should I do, like I did with all the others? 🤔 Given that Jens did not fix them, still the tests pass, which is what matters, but they might break at any point as soon as a transitive package stops depending on a package, which is way too brittle for my taste 😄 🤷🏾 